### PR TITLE
Added a field for filtering the depatures by stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ MagicMirror² Module to monitor public transport (U-bahn, tram, bus, S-Bahn) in 
       showBus: true,    // show bus route
       showTram: true,   // show tram route
       showSbahn: true   // show sbahn route
+      ignoreStations: [] // destination not to be shown
     }
 },
 ```
@@ -41,3 +42,4 @@ MagicMirror² Module to monitor public transport (U-bahn, tram, bus, S-Bahn) in 
 | `showBus` |Show data for Bus. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
 | `showTram` |Show data for Tram. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
 | `showSbahn` |Show data for S-Bahn. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
+| `ignoreStations` |Ignore destinations based on a array list. <br> **Possible values e.g.:** `["Feldmoching", "Hauptbahnhof"]` <br> **Default** `[]` |

--- a/mvgmunich.js
+++ b/mvgmunich.js
@@ -21,7 +21,8 @@ Module.register("mvgmunich", {
     showUbahn: true, //show ubahn route
     showBus: true, // show bus route
     showTram: true, // show tram route
-    showSbahn: true // show sbahn route
+    showSbahn: true, // show sbahn route
+    ignoreStations: []
   },
 
   getStyles: function() {
@@ -67,9 +68,10 @@ Module.register("mvgmunich", {
       })
       var transport = "";
       for (var i in transportItems) {
-        transport += "<tr class='normal'>";
+	transport += "<tr class='normal'>";
         transport += "<td>" + transportItems[i].line + "</td>" + "<td class='stationColumn'>" + transportItems[i].station + "</td>" + "<td>" + transportItems[i].time + "</td>";
         transport += "</tr>";
+
         if (i == this.config.maxEntries - 1) {
           break;
         }

--- a/node_helper.js
+++ b/node_helper.js
@@ -13,6 +13,8 @@ var cheerio = require('cheerio');
 var filter = require('array-filter');
 var request = require('request');
 
+var ignoreStations = [];
+
 module.exports = NodeHelper.create({
 
   start: function() {
@@ -26,6 +28,8 @@ module.exports = NodeHelper.create({
     if (notification === "GETDATA") {
       this.config[payload.identifier] = payload;
       this.updating = true;
+
+     ignoreStations = payload.ignoreStations;
 
       var url = payload.apiBase + "haltestelle=" + payload.haltestelle +
         ((payload.showUbahn) ? "&ubahn=checked" : "") +
@@ -54,7 +58,10 @@ module.exports = NodeHelper.create({
               transportItem.station = $(this).find('td.stationColumn').text().trim();
               transportItem.line = $(this).find('td.lineColumn').text().trim();
               transportItem.time = $(this).find('td.inMinColumn').text().trim();
-              transportItems.push(transportItem);
+	      
+              if (!ignoreStations.includes(transportItem.station)) {
+                transportItems.push(transportItem);
+              }
             })
           }
         });


### PR DESCRIPTION
### Change Description
The current implementation shows all depatures for a given stations, e.g. all S-Bahn depatures. This could be of less value if a station has multiple depatures, e.g. the "Hauptbahnhof" or "Sendlinger Tor". The change enables the user to display only certain destinations by setting a ignore list in the module config. The readme was updateded accordingly.  

### New config parameter
- `ignoreStations: ["String", "String", ...]` of type array. 
- The default value is an empty array []. 

### Implementation
The change checks is the current depature to be displayed is on the ignore list or not. If yes the depature is withdrawn from the display list. 