### PR TITLE
Include time to walk to a station & Ignore Stations

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ MagicMirror² Module to monitor public transport (U-bahn, tram, bus, S-Bahn) in 
       showBus: true,    // show bus route
       showTram: true,   // show tram route
       showSbahn: true   // show sbahn route
+      ignoreStations: [] // destination not to be shown
     }
 },
 ```
@@ -41,3 +42,4 @@ MagicMirror² Module to monitor public transport (U-bahn, tram, bus, S-Bahn) in 
 | `showBus` |Show data for Bus. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
 | `showTram` |Show data for Tram. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
 | `showSbahn` |Show data for S-Bahn. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
+| `ignoreStations` |Ignore destinations based on a array list. <br> **Possible values e.g.:** `["Feldmoching", "Hauptbahnhof"]` <br> **Default** `[]` |

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ MagicMirror² Module to monitor public transport (U-bahn, tram, bus, S-Bahn) in 
       showTram: true,   // show tram route
       showSbahn: true   // show sbahn route
       ignoreStations: [] // destination not to be shown
+      timeToWalk: 10 // 10 min walking time to station. Default is 0
+      includeWalkingTime: false // if the walking time should be included and the starting time is displayed
     }
 },
 ```
@@ -43,3 +45,5 @@ MagicMirror² Module to monitor public transport (U-bahn, tram, bus, S-Bahn) in 
 | `showTram` |Show data for Tram. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
 | `showSbahn` |Show data for S-Bahn. <br> **Possible values:** `true` or `false` <br> **Default:** `true` |
 | `ignoreStations` |Ignore destinations based on a array list. <br> **Possible values e.g.:** `["Feldmoching", "Hauptbahnhof"]` <br> **Default** `[]` |
+| `timeToWalk` | Time to walk to the station from your current location <br> **Default:** `0` minutes |
+| `includeWalkingTime` | If the time to leave should be displayed which includes the walking time. <br> **Default:** `false` |

--- a/mvgmunich.js
+++ b/mvgmunich.js
@@ -4,12 +4,12 @@
  * Magic Mirror
  * Module: MVG Munich
  *
- * By Simon Crnko, Christian Huppertz
+ * By Simon Crnko
  * MIT Licensed
  *
  */
 
-var MS_PER_MINUTE = 60000;
+const MS_PER_MINUTE = 60000;
 
 Module.register("mvgmunich", {
   // Default module configuration
@@ -24,20 +24,21 @@ Module.register("mvgmunich", {
     showBus: true, // show bus route
     showTram: true, // show tram route
     showSbahn: true, // show sbahn route
-    ignoreStations: [], 
-    timeToWalk: 11
+    ignoreStations: [], // list of destination to be ignored in the list
+    timeToWalk: 0, // walking time to the station
+    includeWalkingTime: false // if the walking time should be included and the starting time is displayed
   },
 
-  getStyles: function() {
+  getStyles: function () {
     return ["mvgmunich.css"];
   },
 
-  start: function() {
+  start: function () {
     this.resultData = [];
     var self = this;
     this.config.identifier = this.identifier;
     this.getData();
-    setInterval(function() {
+    setInterval(function () {
       self.updateDom();
     }, this.config.updateInterval);
   },
@@ -47,45 +48,57 @@ Module.register("mvgmunich", {
    * function call getData function in node_helper.js
    *
    */
-  getData: function(identifier) {
+  getData: function (identifier) {
     this.sendSocketNotification("GETDATA", this.config);
   },
 
   // Override dom generator.
-  getDom: function() {
+  getDom: function () {
     var wrapperTable = document.createElement("table");
     wrapperTable.className = "small";
     wrapperTable.innerHTML = this.resultData[this.identifier];
     return wrapperTable;
   },
 
-  processData: function(payload) {
+  processData: function (payload) {
     // we have a runner
     if (payload.error !== "undefined" && payload.error) {
       this.resultData[payload.uuid] = payload.error;
       // we have a data object; Just Do Something
     } else if (payload.transportItems !== "undefined" && payload.transportItems) {
       var transportItems = payload.transportItems;
-      payload.transportItems.sort(function(a, b) {
+      payload.transportItems.sort(function (a, b) {
         return a.time - b.time;
       })
       var transport = "";
       var currentdate = new Date();
 
+      var numOfEntries = 0;
+
       for (var i in transportItems) {
-      
-        // format time string
-        var time = new Date(currentdate.valueOf() + transportItems[i].time*MS_PER_MINUTE - this.config.timeToWalk*MS_PER_MINUTE);
-        var hoursStr = (time.getHours() < 10 ? '0' : '') + time.getHours();
-        var minutesStr = (time.getMinutes() < 10 ? '0' : '') + time.getMinutes();
 
-	      transport += "<tr class='normal'>";
-        transport += "<td>" + transportItems[i].line + "</td>" + "<td class='stationColumn'>" + transportItems[i].station + "</td>" + "<td>" + transportItems[i].time + "</td>"
-                  + "<td>" + hoursStr + ":" + minutesStr + "</td>";
-        transport += "</tr>";
+        // check if current station is not part of the ignore list
+        if (!this.config.ignoreStations.includes(transportItems[i].station)) {
 
-        if (i == this.config.maxEntries - 1) {
-          break;
+          // format time string
+          var time = new Date(currentdate.valueOf() + transportItems[i].time * MS_PER_MINUTE - this.config.timeToWalk * MS_PER_MINUTE);
+          var hoursStr = (time.getHours() < 10 ? '0' : '') + time.getHours();
+          var minutesStr = (time.getMinutes() < 10 ? '0' : '') + time.getMinutes();
+
+          transport += "<tr class='normal'>";
+          transport += "<td>" + transportItems[i].line + "</td>" + "<td class='stationColumn'>" + transportItems[i].station + "</td>" + "<td>" + transportItems[i].time + "</td>";
+
+          if (this.config.includeWalkingTime) {
+            transport += "<td>" + hoursStr + ":" + minutesStr + "</td>";
+          }
+
+          transport += "</tr>";
+
+          numOfEntries++;
+
+          if (numOfEntries === this.config.maxEntries) {
+            break;
+          }
         }
       }
       this.resultData[payload.uuid] = transport;
@@ -93,11 +106,11 @@ Module.register("mvgmunich", {
   },
 
   // Override getHeader method.
-  getHeader: function() {
+  getHeader: function () {
     return this.data.header + " Munich: " + this.config.haltestelle;
   },
 
-  socketNotificationReceived: function(notification, payload) {
+  socketNotificationReceived: function (notification, payload) {
     if (notification === "UPDATE") {
       this.processData(payload);
       this.updateDom();

--- a/mvgmunich.js
+++ b/mvgmunich.js
@@ -21,7 +21,8 @@ Module.register("mvgmunich", {
     showUbahn: true, //show ubahn route
     showBus: true, // show bus route
     showTram: true, // show tram route
-    showSbahn: true // show sbahn route
+    showSbahn: true, // show sbahn route
+    ignoreStations: []
   },
 
   getStyles: function() {
@@ -67,9 +68,10 @@ Module.register("mvgmunich", {
       })
       var transport = "";
       for (var i in transportItems) {
-        transport += "<tr class='normal'>";
+	transport += "<tr class='normal'>";
         transport += "<td>" + transportItems[i].line + "</td>" + "<td class='stationColumn'>" + transportItems[i].station + "</td>" + "<td>" + transportItems[i].time + "</td>";
         transport += "</tr>";
+
         if (i == this.config.maxEntries - 1) {
           break;
         }

--- a/mvgmunich.js
+++ b/mvgmunich.js
@@ -4,10 +4,12 @@
  * Magic Mirror
  * Module: MVG Munich
  *
- * By Simon Crnko
+ * By Simon Crnko, Christian Huppertz
  * MIT Licensed
  *
  */
+
+var MS_PER_MINUTE = 60000;
 
 Module.register("mvgmunich", {
   // Default module configuration
@@ -22,7 +24,8 @@ Module.register("mvgmunich", {
     showBus: true, // show bus route
     showTram: true, // show tram route
     showSbahn: true, // show sbahn route
-    ignoreStations: []
+    ignoreStations: [], 
+    timeToWalk: 11
   },
 
   getStyles: function() {
@@ -67,9 +70,18 @@ Module.register("mvgmunich", {
         return a.time - b.time;
       })
       var transport = "";
+      var currentdate = new Date();
+
       for (var i in transportItems) {
-	transport += "<tr class='normal'>";
-        transport += "<td>" + transportItems[i].line + "</td>" + "<td class='stationColumn'>" + transportItems[i].station + "</td>" + "<td>" + transportItems[i].time + "</td>";
+      
+        // format time string
+        var time = new Date(currentdate.valueOf() + transportItems[i].time*MS_PER_MINUTE - this.config.timeToWalk*MS_PER_MINUTE);
+        var hoursStr = (time.getHours() < 10 ? '0' : '') + time.getHours();
+        var minutesStr = (time.getMinutes() < 10 ? '0' : '') + time.getMinutes();
+
+	      transport += "<tr class='normal'>";
+        transport += "<td>" + transportItems[i].line + "</td>" + "<td class='stationColumn'>" + transportItems[i].station + "</td>" + "<td>" + transportItems[i].time + "</td>"
+                  + "<td>" + hoursStr + ":" + minutesStr + "</td>";
         transport += "</tr>";
 
         if (i == this.config.maxEntries - 1) {

--- a/node_helper.js
+++ b/node_helper.js
@@ -13,8 +13,6 @@ var cheerio = require('cheerio');
 var filter = require('array-filter');
 var request = require('request');
 
-var ignoreStations = [];
-
 module.exports = NodeHelper.create({
 
   start: function() {
@@ -59,9 +57,7 @@ module.exports = NodeHelper.create({
               transportItem.line = $(this).find('td.lineColumn').text().trim();
               transportItem.time = $(this).find('td.inMinColumn').text().trim();
 	      
-              if (!ignoreStations.includes(transportItem.station)) {
-                transportItems.push(transportItem);
-              }
+              transportItems.push(transportItem);
             })
           }
         });

--- a/node_helper.js
+++ b/node_helper.js
@@ -13,6 +13,8 @@ var cheerio = require('cheerio');
 var filter = require('array-filter');
 var request = require('request');
 
+var ignoreStations = [];
+
 module.exports = NodeHelper.create({
 
   start: function() {
@@ -26,6 +28,8 @@ module.exports = NodeHelper.create({
     if (notification === "GETDATA") {
       this.config[payload.identifier] = payload;
       this.updating = true;
+
+     ignoreStations = payload.ignoreStations;
 
       var url = payload.apiBase + "haltestelle=" + payload.haltestelle +
         ((payload.showUbahn) ? "&ubahn=checked" : "") +
@@ -54,7 +58,10 @@ module.exports = NodeHelper.create({
               transportItem.station = $(this).find('td.stationColumn').text().trim();
               transportItem.line = $(this).find('td.lineColumn').text().trim();
               transportItem.time = $(this).find('td.inMinColumn').text().trim();
-              transportItems.push(transportItem);
+	      
+              if (!ignoreStations.includes(transportItem.station)) {
+                transportItems.push(transportItem);
+              }
             })
           }
         });

--- a/node_helper.js
+++ b/node_helper.js
@@ -27,8 +27,6 @@ module.exports = NodeHelper.create({
       this.config[payload.identifier] = payload;
       this.updating = true;
 
-     ignoreStations = payload.ignoreStations;
-
       var url = payload.apiBase + "haltestelle=" + payload.haltestelle +
         ((payload.showUbahn) ? "&ubahn=checked" : "") +
         ((payload.showBus) ? "&bus=checked" : "") +


### PR DESCRIPTION
## IgnoreStations
### Change Description
The current implementation shows all depatures for a given stations, e.g. all S-Bahn depatures. This could be of less value if a station has multiple depatures, e.g. the "Hauptbahnhof" or "Sendlinger Tor". The change enables the user to display only certain destinations by setting a ignore list in the module config. The readme was updateded accordingly.  

### New config parameter
- `ignoreStations: ["String", "String", ...]` of type array. 
- The default value is an empty array []. 

### Implementation
The change checks is the current depature to be displayed is on the ignore list or not. If yes the depature is withdrawn from the display list. 

## Include Walking Time
### Change Description
The current implementation shows the time the next trains etc. depart. The chance includes a new feature to display the time to leave time for the next trains. In addition an adpation to the max. entry numbers had to be made to display the correct max. entries. 

### New config parameter
- timeToWalk: The time in minutes to walk to the station. Default is 0.
- includeWalkintTime: If the time to leave should be displayed. Default is false

### Implementation
`currentTime + depatareTimeMinutes - WalktinTime`


