### PR TITLE
Cut off string of lenghty destinations

### DIFF
--- a/mvgmunich.js
+++ b/mvgmunich.js
@@ -108,7 +108,7 @@ Module.register("mvgmunich", {
 			// add transport number
 			htmlText += "<td>" + apiResultItem.label + "</td>";
 			// add last station aka direction
-			htmlText += "<td class='stationColumn'>" + apiResultItem.destination + "</td>";
+			htmlText += "<td class='stationColumn'>" + apiResultItem.destination.split(" - ")[0] + "</td>";
 			// check if user want's to see departure time
 			htmlText += this.showDepartureTime(apiResultItem.departureTime, this.config);
 			// check if user want's to see walking time


### PR DESCRIPTION
Some bus lines exceed maximum number of characters, i.e. CityRing via Ostbahnhof - Silberhornstraße.
The change cuts off at " - ". Might also make sense to parameterize in config file to only cut off if user wants it to.